### PR TITLE
Added debug history flag

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -2246,8 +2246,8 @@ if ($chem eq 'trop_mam_oslo' or $chem eq 'tropstrat_mam_oslo') {
                  'BC_NI    -> ' =>'bc_ni_oslo_emis_file',
                  'SO4_PR   -> ' =>'so4_pr_oslo_emis_file',
                  'OM_NI    -> ' =>'om_ni_oslo_emis_file',
-	 	           'monoterp -> ' => 'monoterp_oslo_emis_file',
-		           'isoprene -> ' => 'isoprene_oslo_emis_file',
+                 'monoterp -> ' => 'monoterp_oslo_emis_file',
+		         'isoprene -> ' => 'isoprene_oslo_emis_file',
                  );
 
     my $first = 1;
@@ -2323,7 +2323,7 @@ if ($chem eq 'trop_mam_oslo' or $chem eq 'tropstrat_mam_oslo') {
         }
     }
     if ($chem eq 'tropstrat_mam_oslo') {
-    
+
         my @files = ('soil_erod_file',
 #                    'xs_long_file', 'rsf_file', 'exo_coldens_file' );
 #                    'xs_long_file', 'xs_short_file', 'xs_coef_file', 'rsf_file', 'exo_coldens_file' );
@@ -3695,10 +3695,11 @@ add_default($nl, 'history_chemspecies_srf');
 add_default($nl, 'history_clubb');
 add_default($nl, 'history_dust');
 add_default($nl, 'history_aerosol_base');
-add_default($nl, 'history_aerosol_decomposed'); 
-add_default($nl, 'history_gas'); 
-add_default($nl, 'history_aerosol_forcing'); 
-add_default($nl, 'history_aerosol_radiation'); 
+add_default($nl, 'history_aerosol_decomposed');
+add_default($nl, 'history_gas');
+add_default($nl, 'history_aerosol_forcing');
+add_default($nl, 'history_aerosol_radiation');
+add_default($nl, 'history_aerosol_debug_output');
 
 
 # The history output for the AMWG variability diagnostics assumes that auxilliary history

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -1754,7 +1754,8 @@
 <history_aerosol_decomposed>          .false.  </history_aerosol_decomposed>
 <history_gas>                         .false.  </history_gas>
 <history_aerosol_forcing>             .false.  </history_aerosol_forcing>
-<history_aerosol_radiation>           .false.  </history_aerosol_radiation>       
+<history_aerosol_radiation>           .false.  </history_aerosol_radiation>
+<history_aerosol_debug_output>        .false.  </history_aerosol_debug_output>
 
 <!-- ================================================================== -->
 <!-- Defaults for SE                                                    -->

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -4299,32 +4299,32 @@ Default: .false.
        group="phys_ctl_nl" valid_values="" >
 Switch to turn on/off output of compounded aerosols (BC, DUST, OM, SALT, SULFATE) and gas-phase column burdens from OsloAero.
 Also controls output of other key aerosol specific outputs
-Default: .true. 
+Default: .true.
 </entry>
 
 <entry id="history_aerosol_decomposed" type="logical" category="diagnostics"
        group="phys_ctl_nl" valid_values="" >
 Switch to turn on/off output of decomposed aerosols from OsloAero.
-Default: .false. 
+Default: .false.
 </entry>
 
 <entry id="history_gas" type="logical" category="diagnostics"
        group="phys_ctl_nl" valid_values="" >
-Switch to turn on/off output of 3D gasphase aerosols from OsloAero. 
+Switch to turn on/off output of 3D gasphase aerosols from OsloAero.
 NOTE; the 2D column burdens are triggered by history_aerosol_base.
-Default: .false.  
+Default: .false.
 </entry>
 
 <entry id="history_aerosol_forcing" type="logical" category="diagnostics"
        group="phys_ctl_nl" valid_values="" >
 Switch to turn on/off output of forcing specific species in OsloAero.
-Default: .false. 
+Default: .false.
 </entry>
 
 <entry id="history_aerosol_radiation" type="logical" category="diagnostics"
        group="phys_ctl_nl" valid_values="" >
 Switch to turn on/off output of aerosol radiative properties.
-Default: .false. 
+Default: .false.
 </entry>
 
 <entry id="offline_driver" type="logical" category="offline_unit_driver"

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -4327,6 +4327,13 @@ Switch to turn on/off output of aerosol radiative properties.
 Default: .false.
 </entry>
 
+<entry id="history_aerosol_debug_output" type="logical" category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Switch to turn on/off output for debugging summation from OsloAero.
+Default: .false.
+</entry>
+
+
 <entry id="offline_driver" type="logical" category="offline_unit_driver"
        group="phys_ctl_nl" valid_values="" >
 True when model is configured to use an offline driver.

--- a/src/NorESM/phys_control.F90
+++ b/src/NorESM/phys_control.F90
@@ -36,7 +36,7 @@ integer,           parameter :: unset_int = huge(1)
 
 ! Namelist variables:
 character(len=16) :: cam_physpkg          = unset_str  ! CAM physics package
-character(len=32) :: cam_chempkg          = unset_str  ! CAM chemistry package 
+character(len=32) :: cam_chempkg          = unset_str  ! CAM chemistry package
 character(len=16) :: waccmx_opt           = unset_str  ! WACCMX run option [ionosphere | neutral | off
 character(len=16) :: deep_scheme          = unset_str  ! deep convection package
 character(len=16) :: shallow_scheme       = unset_str  ! shallow convection package
@@ -70,11 +70,12 @@ logical           :: history_dust         = .false.
 logical           :: history_cesm_forcing = .false.
 logical           :: history_scwaccm_forcing = .false.
 logical           :: history_chemspecies_srf = .false.
-logical, public, protected :: history_aerosol_base       = .true.     
-logical, public, protected :: history_aerosol_decomposed = .false.
-logical, public, protected :: history_gas                = .false.
-logical, public, protected :: history_aerosol_forcing    = .false.
-logical, public, protected :: history_aerosol_radiation  = .false.
+logical, public, protected :: history_aerosol_base          = .true.
+logical, public, protected :: history_aerosol_decomposed    = .false.
+logical, public, protected :: history_gas                   = .false.
+logical, public, protected :: history_aerosol_forcing       = .false.
+logical, public, protected :: history_aerosol_radiation     = .false.
+logical, public, protected :: history_aerosol_debug_output  = .false.
 
 logical           :: do_clubb_sgs
 ! Check validity of physics_state objects in physics_update.
@@ -108,9 +109,9 @@ logical, public, protected :: fv_am_correction = .false.
 !tht: energy adjustment in dry mass adjustment
 logical, public, protected :: dme_energy_adjust = .false.
 
-!======================================================================= 
+!=======================================================================
 contains
-!======================================================================= 
+!=======================================================================
 
 subroutine phys_ctl_readnl(nlfile)
 
@@ -131,7 +132,7 @@ subroutine phys_ctl_readnl(nlfile)
       use_subcol_microp, atm_dep_flux, history_amwg, history_vdiag, history_aerosol, history_aero_optics, &
       history_eddy, history_budget,  history_budget_histfile_num, history_waccm, &
       history_waccmx, history_chemistry, history_carma, history_clubb, history_dust, &
-      history_cesm_forcing, history_scwaccm_forcing, history_chemspecies_srf, history_aerosol_base, & 
+      history_cesm_forcing, history_scwaccm_forcing, history_chemspecies_srf, history_aerosol_base, history_aerosol_debug_output, &
       history_aerosol_decomposed, history_gas, history_aerosol_forcing, history_aerosol_radiation, &
       do_clubb_sgs, state_debug_checks, use_hetfrz_classnuc, use_gw_oro, use_gw_front, &
       use_gw_front_igw, use_gw_convect_dp, use_gw_convect_sh, cld_macmic_num_steps, &
@@ -186,6 +187,7 @@ subroutine phys_ctl_readnl(nlfile)
    call mpi_bcast(history_gas,                 1,                     mpi_logical,   masterprocid, mpicom, ierr)
    call mpi_bcast(history_aerosol_forcing,     1,                     mpi_logical,   masterprocid, mpicom, ierr)
    call mpi_bcast(history_aerosol_radiation,   1,                     mpi_logical,   masterprocid, mpicom, ierr)
+   call mpi_bcast(history_aerosol_debug_output,1,                     mpi_logical,   masterprocid, mpicom, ierr)
    call mpi_bcast(history_scwaccm_forcing,     1,                     mpi_logical,   masterprocid, mpicom, ierr)
    call mpi_bcast(do_clubb_sgs,                1,                     mpi_logical,   masterprocid, mpicom, ierr)
    call mpi_bcast(state_debug_checks,          1,                     mpi_logical,   masterprocid, mpicom, ierr)
@@ -223,7 +225,7 @@ subroutine phys_ctl_readnl(nlfile)
       write(iulog,*)'UW PBL is not compatible with RK microphysics.  Quiting'
       call endrun('PBL and Microphysics schemes incompatible')
    endif
-   
+
    ! Add a check to make sure CLUBB and MG are used together
    if ( do_clubb_sgs .and. ( microp_scheme .ne. 'MG') .and. .not. use_spcam) then
       write(iulog,*)'CLUBB is only compatible with MG microphysics.  Quiting'
@@ -237,7 +239,7 @@ subroutine phys_ctl_readnl(nlfile)
          call endrun('CLUBB and eddy, macrop or shallow schemes incompatible')
       endif
    endif
-      
+
    ! Macro/micro co-substepping support.
    if (cld_macmic_num_steps > 1) then
       if (microp_scheme /= "MG" .or. (macrop_scheme /= "park" .and. macrop_scheme /= "CLUBB_SGS")) then
@@ -250,7 +252,7 @@ subroutine phys_ctl_readnl(nlfile)
    prog_modal_aero = index(cam_chempkg,'_mam')>0
 #ifdef OSLO_AERO
    prog_modal_aero = .FALSE.
-#endif 
+#endif
 end subroutine phys_ctl_readnl
 
 !===============================================================================
@@ -260,7 +262,7 @@ logical function cam_physpkg_is(name)
    ! query for the name of the physics package
 
    character(len=*) :: name
-   
+
    cam_physpkg_is = (trim(name) == trim(cam_physpkg))
 end function cam_physpkg_is
 
@@ -271,7 +273,7 @@ logical function cam_chempkg_is(name)
    ! query for the name of the chemics package
 
    character(len=*) :: name
-   
+
    cam_chempkg_is = (trim(name) == trim(cam_chempkg))
 end function cam_chempkg_is
 
@@ -282,7 +284,7 @@ logical function waccmx_is(name)
    ! query for the name of the waccmx run option
 
    character(len=*) :: name
-   
+
    waccmx_is = (trim(name) == trim(waccmx_opt))
 end function waccmx_is
 


### PR DESCRIPTION
Added history_aerosol_debug_output flag. It contains four output fields that is needed to perform control calculations of summation fields in OsloAero. 

Also, some whitespace removal.